### PR TITLE
Add a permanent redirect for objects.inv -> stable/objects.inv

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -55,6 +55,9 @@
 	import subproject mpl-gui
 	import subproject mpl-third-party
 
+	# redirect the objects.inv
+	redir /objects.inv /stable/objects.inv permanent
+
 	# Place the brochure site at the top level.
 	import subproject mpl-brochure-site
 	@brochure file {


### PR DESCRIPTION
see discussion at
https://github.com/matplotlib/matplotlib/issues/22601#issuecomment-1063566310

This should make sphinx issues warnings that the objects.inv has moved and
generate correct links.