### PR TITLE
Tell Caddy the host internal FQDN

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -50,10 +50,10 @@ http://{{ caddy.addresses.webhook }} {
 }
 
 {% if caddy.tls_config is defined %}
-https://{{ caddy.addresses.main }} {
+https://{{ caddy.addresses.main }}, https://{{ ansible_fqdn }} {
 	{{ caddy.tls_config }}
 {% else %}
-http://{{ caddy.addresses.main }} {
+http://{{ caddy.addresses.main }}, http://{{ ansible_fqdn }} {
 {% endif %}
 
 	root * {{ caddy.site_dir }}


### PR DESCRIPTION
This allows connecting to, e.g., `venus.matplotlib.org`.