### PR TITLE
Hide .git folders from website

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -8,7 +8,9 @@
 	handle_path /{args.0}/* {
 		root * {{ caddy.site_dir }}/{args.0}
 		try_files {path}.html {path}
-		file_server
+		file_server {
+			hide .git
+		}
 	}
 }
 
@@ -77,7 +79,9 @@ http://{{ caddy.addresses.main }}, http://{{ ansible_fqdn }} {
 	handle {
 		root * {{ caddy.site_dir }}/matplotlib.github.com
 		try_files {path}.html {path}
-		file_server
+		file_server {
+			hide .git
+		}
 	}
 
 	# Use a custom 404 error page.
@@ -85,6 +89,8 @@ http://{{ caddy.addresses.main }}, http://{{ ansible_fqdn }} {
 		@notfound expression {http.error.status_code} == 404
 		root * {{ caddy.site_dir }}/mpl-brochure-site
 		rewrite @notfound /404.html
-		file_server
+		file_server {
+			hide .git
+		}
 	}
 }


### PR DESCRIPTION
This is generally considered a security issue, but it's kind of meaningless for us since we are serving public repos that contain no secrets, nor are running any webapps that could accidentally expose anything from it.

But we can hide it to satisfy security scanners.