### PR TITLE
Restart webhook service on failure

### DIFF
--- a/webhook/webhook.service
+++ b/webhook/webhook.service
@@ -11,6 +11,7 @@ User=caddy
 Group=caddy
 ExecStart=/usr/bin/python3 /usr/bin/webhook.py localhost:1234
 EnvironmentFile=/etc/caddy/webhook.env
+Restart=on-failure
 TimeoutStopSec=5s
 LimitNOFILE=1048576
 LimitNPROC=512


### PR DESCRIPTION
Some weeks ago, a `git gc` OOM'd which took out the whole webhook service slice. I restarted it manually when I saw it but the service manager should auto-restart it.