### PR TITLE
Add a ping endpoint to webhook service

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -46,6 +46,16 @@ http://{{ caddy.addresses.webhook }} {
 		}
 	}
 
+	handle /ping {
+		reverse_proxy * localhost:1234 {
+			# Don't leak out internal problems.
+			@error status 4xx 5xx
+			handle_response @error {
+				error 503
+			}
+		}
+	}
+
 	handle {
 		error 404
 	}

--- a/webhook/test_webhook.py
+++ b/webhook/test_webhook.py
@@ -65,6 +65,15 @@ async def test_update_repo(tmp_path_factory):
     assert dest_commit == src_commit
 
 
+async def test_ping(aiohttp_client, monkeypatch, tmp_path):
+    """Test ping always works."""
+    monkeypatch.setenv('SITE_DIR', str(tmp_path))
+    client = await aiohttp_client(create_app())
+
+    resp = await client.get('/ping')
+    assert resp.status == 200
+
+
 async def test_github_webhook_errors(aiohttp_client, monkeypatch, tmp_path):
     """Test invalid inputs to webhook."""
     monkeypatch.setenv('SITE_DIR', str(tmp_path))

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -173,6 +173,11 @@ async def github_webhook(request: web.Request):
     return web.Response(status=200)
 
 
+async def ping(request: web.Request):
+    """Respond to a ping, thus verifying the webhook service is alive."""
+    return web.Response(status=200)
+
+
 def create_app():
     """Create the aiohttp app and setup routes."""
     site_dir = Path(os.environ.get('SITE_DIR', 'sites')).resolve()
@@ -182,6 +187,7 @@ def create_app():
     app['site_dir'] = site_dir
     app.add_routes([
         web.post('/gh/{repo}', github_webhook),
+        web.get('/ping', ping),
     ])
     return app
 


### PR DESCRIPTION
As noted in #25, the webhook was down for some period.

Previously, our health check was hitting `/gh` and looking for a 404. However, the Caddy config only passes `/gh/*` to the webhook, with a 404 for any other path. This meant that the checked path was always hitting Caddy's fall back and _never_ actually checking that the webhook service was up. With a `/ping` endpoint, we have a dedicated URL to check and it can return a normal 200. If Caddy cannot connect to the webhook, it will return 502 instead of 200.

