### PR TITLE
Use consistent branch for matplotlib.github.com

### DIFF
--- a/matplotlib.org.yml
+++ b/matplotlib.org.yml
@@ -164,7 +164,10 @@
           ansible.builtin.git:
             repo: "https://github.com/matplotlib/{{ item }}"
             dest: "/usr/share/caddy/{{ item }}"
-            version: gh-pages
+            version: >-
+              {{
+                (item == 'matplotlib.github.com') | ternary('main', 'gh-pages')
+              }}
           loop: "{{ repos }}"
 
     # Caddy server setup


### PR DESCRIPTION
The webhook uses `main`, but the playbook always used `gh-pages`. This caused things to be out of sync when the playbook was  run for the `mpl-sphinx-theme` addition.