### PR TITLE
Make search go to stable docs instead of the mostly-empty brochure site

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -80,6 +80,8 @@ http://{{ caddy.addresses.main }}, http://{{ ansible_fqdn }} {
 
 	# redirect the objects.inv
 	redir /objects.inv /stable/objects.inv permanent
+	# Make search go to the actual docs instead of the mostly-empty brochure site.
+	redir /search.html /stable/search.html?{query} temporary
 
 	# Place the brochure site at the top level.
 	@brochure file {


### PR DESCRIPTION
This is temporary, as I would like to figure out how to modify the theme so that the form goes directly to the right page instead.

It is also already deployed.

cf matplotlib/mpl-brochure-site#65