### PR TITLE
Test webhook against newer Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
We are running the server on F39, which has Python 3.12, so we should be testing there, instead of the older 3.9/3.10.