### PR TITLE
Improve logging from webhook

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -22,6 +22,15 @@ https://{{ caddy.addresses.webhook }} {
 http://{{ caddy.addresses.webhook }} {
 {% endif %}
 
+	# Include access logs when an error occurs, since we mask any internal errors
+	# from escaping to the outside world, but otherwise don't log.
+	log {
+		output discard
+	}
+	log errors {
+		no_hostname
+	}
+
 	root * {{ caddy.site_dir }}
 
 	# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#delivery-headers
@@ -41,6 +50,9 @@ http://{{ caddy.addresses.webhook }} {
 			# Don't leak out internal problems.
 			@error status 4xx 5xx
 			handle_response @error {
+				log_name errors
+				log_append api_error_code {rp.status_code}
+				log_append api_error_text {rp.status_text}
 				error 400
 			}
 		}
@@ -51,6 +63,9 @@ http://{{ caddy.addresses.webhook }} {
 			# Don't leak out internal problems.
 			@error status 4xx 5xx
 			handle_response @error {
+				log_name errors
+				log_append api_error_code {rp.status_code}
+				log_append api_error_text {rp.status_text}
 				error 503
 			}
 		}


### PR DESCRIPTION
When an error occurs in the webhook (either with itself or due to invalid input), it returns a 4xx/5xx and some error text. For security reasons, Caddy reduces all of these results to a simple 400/503. Since aiohttp only logs the response code, and Caddy only logs admin problems, this information was lost.

We don't really do anything with access logs, so just enable them only for the errors.

Note this is already deployed, and if I request something invalid:
```
$ http POST https://do.matplotlib.org/gh/matplotlib.github.com \
    Content-Type:application/json \
    User-Agent:GitHub-Hookshot/foo \
    X-GitHub-Event:push \
    X-GitHub-Delivery:foo \
    X-Hub-Signature-256:bar \
    -v < /dev/null
```
then in the Caddy journal, we get:
```
Feb 13 09:15:54 mercury.matplotlib.org caddy[464235]: {
  "level": "info",
  "ts": 1739438154.6256573,
  "logger": "http.log.access.errors",
  "msg": "handled request",
  "request": {
    "remote_ip": "...",
    "remote_port": "63586",
    "client_ip": "...",
    "proto": "HTTP/2.0",
    "method": "POST",
    "host": "do.matplotlib.org",
    "uri": "/gh/matplotlib.github.com",
    "headers": {
      "Cf-Visitor": ["{\"scheme\":\"https\"}"],
      "Cdn-Loop": ["cloudflare; loops=1"],
      "Cf-Ray": ["..."],
      "Cf-Ipcountry": ["CA"],
      "Content-Length": ["0"],
      "X-Github-Event": ["push"],
      "Cf-Connecting-Ip": ["..."],
      "Accept-Encoding": ["gzip, br"],
      "X-Hub-Signature-256": ["bar"],
      "X-Github-Delivery": ["foo"],
      "Content-Type": ["application/json"],
      "Accept": ["application/json, */*;q=0.5"],
      "User-Agent": ["GitHub-Hookshot/foo"],
      "X-Forwarded-For": ["..."],
      "X-Forwarded-Proto": ["https"]
    },
    "tls": {
      "resumed": false,
      "version": 772,
      "proto": "h2",
      "server_name": "do.matplotlib.org"
    }
  },
  "bytes_read": 0,
  "user_id": "",
  "duration": 0.232858129,
  "size": 0,
  "status": 400,
  "resp_headers": {
    "Server": ["Caddy"],
    "Alt-Svc": ["h3=\":443\"; ma=2592000"]
  },
  "api_error_text": "400 foo: webhook signature was invalid",
  "api_error_code": 400
}
```