### PR TITLE
Set upload limits consistently

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -33,6 +33,10 @@ http://{{ caddy.addresses.webhook }} {
 
 	root * {{ caddy.site_dir }}
 
+	request_body {
+		max_size 25MB  # Limit from GitHub.
+	}
+
 	# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#delivery-headers
 	@valid_webhook {
 		path /gh/*
@@ -84,6 +88,10 @@ http://{{ caddy.addresses.main }}, http://{{ ansible_fqdn }} {
 {% endif %}
 
 	root * {{ caddy.site_dir }}
+
+	request_body {
+		max_size 0
+	}
 
 {% for site, path in repos.items() %}
 	import subproject {{ site }} {{ path | default(site, true) }}

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -88,10 +88,6 @@ async def github_webhook(request: web.Request):
 
     We only handle ping and push events (this is enforced by the Caddyfile).
     """
-    # Verify some input parameters.
-    if request.content_length > 25_000_000:  # Limit from GitHub.
-        raise web.HTTPBadRequest(reason='Request too large')
-
     # This should be guarded against by Caddy, but check anyway.
     # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#delivery-headers
     try:
@@ -183,7 +179,7 @@ def create_app():
     site_dir = Path(os.environ.get('SITE_DIR', 'sites')).resolve()
     assert site_dir.is_dir()
 
-    app = web.Application()
+    app = web.Application(client_max_size=25_000_000)  # Limit from GitHub.
     app['site_dir'] = site_dir
     app.add_routes([
         web.post('/gh/{repo}', github_webhook),


### PR DESCRIPTION
We previously checked that the content was below GitHub's 25M limit, but this was done in the request handler. `aiohttp` _already_ checks the content size and has a limit of 1 MiB.

Instead, set the limit for `aiohttp` and for Caddy directly. Though the latter is redundant, it's possibly a bit more secure. Limiting upload to the regular site is also probably redundant since it goes to `file_server` which supports no uploads, but better to cut that off early. CloudFlare also has a limit set, but it's to its minimum allowed which is 100MB.