### PR TITLE
Update to Fedora 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,9 @@ Note down the outputs to verify later, e.g.,
 
 ```
 # Use these for comparison when connecting yourself.
-1024 SHA256:J2sbqvhI/VszBtVvPabgxyz6sRnGLrZUn0kqfv4doAM root@mercury.matplotlib.org (DSA)
-256 SHA256:J0rOMayXhL1+5wbm4WQNpAvmscDjqwJjAtk1SLemRMI root@mercury.matplotlib.org (ECDSA)
-256 SHA256:y8EDRGMpLWOW72x47MVKsAfSAl8JHjsOc/RGaiMTPGs root@mercury.matplotlib.org (ED25519)
-3072 SHA256:AyuNO8FES5k9vobv0Pu9XpvtjVFZ1bTTNxb1lo+AuRA root@mercury.matplotlib.org (RSA)
+256 SHA256:p6MiA8+IO1WcpXHDOQ4rhiVCo+MDxWB7ehfNfxvbDkU root@venus.matplotlib.org (ECDSA)
+256 SHA256:RfDahJqnQFLeFN+zl9f+hmB+W05OoZK26NfNQkj6KtY root@venus.matplotlib.org (ED25519)
+3072 SHA256:tYwdULlz5/XP5Ze7PCj9XpO3VIMEZkiOiFuhr9nke34 root@venus.matplotlib.org (RSA)
 ```
 
 Finally, you should reboot the droplet. This is due to a bug in cloud-init on

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ ansible-playbook create.yml --extra-vars "host=pluto functional=web99 ssh_keys='
 
 The playbook will create the server, as well as add DNS records on CloudFlare.
 Note, you must set `DO_API_TOKEN` and `CLOUDFLARE_TOKEN` in the environment to
-access these services.
+access these services. The droplet ID and IP address will be printed at the
+end of the playbook.
 
 Then, to ensure you are connecting to the expected server, you should grab the
 SSH host keys via the DigitalOcean Droplet Console:
@@ -172,6 +173,12 @@ Note down the outputs to verify later, e.g.,
 Finally, you should reboot the droplet. This is due to a bug in cloud-init on
 DigitalOcean, which generates a new machine ID after startup, causing system
 logs to be seem invisible.
+
+This can be done from the Console, or via the CLI:
+
+```
+doctl compute droplet-action reboot <droplet-id>
+```
 
 Running Ansible
 ---------------

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Initial setup
 The summary of the initial setup is:
 
 1. Create the droplet with monitoring and relevant SSH keys.
-2. Assign new droplet to the matplotlib.org project and the Web firewall.
+2. Assign new droplet to the matplotlib.org project.
 3. Add DNS entries pointing to the server on CloudFlare.
 4. Grab the SSH host fingerprints.
 5. Reboot.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ Before you can run our Ansible playbooks, you need to meet the following
 prerequisites:
 
 * Create a DigitalOcean API token, and pass it to the inventory generator by
-  setting the `DO_API_TOKEN` environment variable.
+  setting the `DO_API_TOKEN` environment variable. The API token must have
+  access to the following scopes:
+    - Read: droplet, firewall, monitoring, project, ssh_key
+    - Create: droplet
+    - Update: droplet, monitoring, project
 * If you are creating a new droplet, and want to configure DNS as well, then
-  create a CloudFlare API token, and pass it to the Ansible playbook by setting
-  the `CLOUDFLARE_TOKEN` environment variable.
+  create a CloudFlare API token with DNS edit permissions, and pass it to the
+  Ansible playbook by setting the `CLOUDFLARE_TOKEN` environment variable.
 * Set the vault decryption password of the Ansible vaulted file with our
   secrets. This may be done by setting the `ANSIBLE_VAULT_PASSWORD_FILE`
   environment variable to point to a file containing the password.

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -2,5 +2,5 @@
 collections:
   - name: ansible.posix
   - name: community.general
-    version: ">=2.0.0"
+    version: ">=8.0.0"
   - name: community.digitalocean

--- a/create.yml
+++ b/create.yml
@@ -91,8 +91,6 @@
       community.digitalocean.digital_ocean_droplet:
         state: present
         name: "{{ host }}.matplotlib.org"
-        firewall:
-          - Web
         image: fedora-39-x64
         monitoring: true
         project: matplotlib.org

--- a/create.yml
+++ b/create.yml
@@ -91,7 +91,7 @@
       community.digitalocean.digital_ocean_droplet:
         state: present
         name: "{{ host }}.matplotlib.org"
-        image: fedora-39-x64
+        image: fedora-41-x64
         monitoring: true
         project: matplotlib.org
         region: tor1

--- a/create.yml
+++ b/create.yml
@@ -115,6 +115,8 @@
             map(attribute='ip_address') |
             first
           }}
+        tags:
+          - website
         zone: matplotlib.org
 
     - name: Setup functional DNS for droplet on CloudFlare
@@ -124,7 +126,22 @@
         record: "{{ functional }}"
         type: CNAME
         value: "{{ host }}.matplotlib.org"
+        tags:
+          - website
         zone: matplotlib.org
+
+    - name: Print droplet info
+      ansible.builtin.debug:
+        msg:
+          - "Droplet ID is {{ new_droplet.data.droplet.id }}"
+          - >-
+              First Public IPv4 is {{
+                (new_droplet.data.droplet.networks.v4 | selectattr('type', 'equalto', 'public')).0.ip_address |
+                default('<none>', true) }}
+          - >-
+              First Private IPv4 is {{
+                (new_droplet.data.droplet.networks.v4 | selectattr('type', 'equalto', 'private')).0.ip_address |
+                default('<none>', true) }}
 
   vars:
     # We currently name servers based on planets in the Solar System.

--- a/files/dnf5-automatic.conf
+++ b/files/dnf5-automatic.conf
@@ -1,0 +1,2 @@
+[commands]
+apply_updates = yes

--- a/matplotlib.org.yml
+++ b/matplotlib.org.yml
@@ -45,7 +45,7 @@
         - name: Install server maintenance
           ansible.builtin.dnf:
             name:
-              - dnf-automatic
+              - dnf5-plugin-automatic
               - fail2ban
             state: present
 
@@ -63,8 +63,8 @@
             name:
               - golang-github-prometheus
               - golang-github-prometheus-alertmanager
-              - golang-github-prometheus-node-exporter
               - grafana
+              - node-exporter
               # Remove this when Loki is packaged.
               - podman
             state: present
@@ -77,9 +77,14 @@
 
     # Automatic updates
     # #################
+    - name: Configure automatic updates
+      ansible.builtin.copy:
+        src: dnf5-automatic.conf
+        dest: /etc/dnf/dnf5-plugins/automatic.conf
+
     - name: Enable automatic updates
       ansible.builtin.systemd:
-        name: dnf-automatic-install.timer
+        name: dnf5-automatic.timer
         enabled: true
         state: started
 


### PR DESCRIPTION
Also add additional documentation and sync things with new tag behaviour. See commits for details.

This is now running on venus.matplotlib.org, which will replace mercury after some testing.